### PR TITLE
Add a %addon argument to reverse the display of the text

### DIFF
--- a/org_fedora_hello_world/gui/spokes/hello_world.py
+++ b/org_fedora_hello_world/gui/spokes/hello_world.py
@@ -192,6 +192,11 @@ class HelloWorldSpoke(FirstbootSpokeMixIn, NormalSpoke):
         """
 
         text = self.data.addons.org_fedora_hello_world.text
+
+        # If --reverse was specified in the kickstart, reverse the text
+        if self.data.addons.org_fedora_hello_world.reverse:
+            text = text[::-1]
+
         if text:
             return _("Text set: %s") % text
         else:

--- a/org_fedora_hello_world/tui/spokes/hello_world.py
+++ b/org_fedora_hello_world/tui/spokes/hello_world.py
@@ -163,6 +163,11 @@ class HelloWorldSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
         """
 
         text = self.data.addons.org_fedora_hello_world.text
+
+        # If --reverse was specified in the kickstart, reverse the text
+        if self.data.addons.org_fedora_hello_world.reverse:
+            text = text[::-1]
+
         if text:
             return _("Text set: %s") % text
         else:


### PR DESCRIPTION
This allows for a --reverse argument on the %addon line, such as:

  %addon org_fedora_hello_world --reverse
  text goes here
  %end

If specified in the kickstart, the Hello World status displayed in the
GUI and the TUI will be the reverse of what was input. This option is
only exposed through kickstart.
