### PR TITLE
Fix whitespace issues in the %addon output

### DIFF
--- a/org_fedora_hello_world/ks/hello_world.py
+++ b/org_fedora_hello_world/ks/hello_world.py
@@ -63,9 +63,9 @@ class HelloWorldData(AddonData):
         addon_str = "%%addon %s" % self.name
 
         if self.reverse:
-            addon_str += "--reverse"
+            addon_str += " --reverse"
 
-        addon_str += "\n%s\n%%end" % self.text
+        addon_str += "\n%s\n%%end\n" % self.text
         return addon_str
 
     def handle_header(self, lineno, args):


### PR DESCRIPTION
There was no space between the addon name and the parameter, so the
resulting kickstart would end up with a line like

  %addon org_fedora_hello_world--reverse

Also add a \n after %end so that subsequent addons start on a new line.
