### PR TITLE
Add support for new Anaconda addon methods (#1288636)

### DIFF
--- a/org_fedora_hello_world/ks/hello_world.py
+++ b/org_fedora_hello_world/ks/hello_world.py
@@ -131,7 +131,7 @@ class HelloWorldData(AddonData):
         # no actions needed in this addon
         pass
 
-    def setup(self, storage, ksdata, instclass):
+    def setup(self, storage, ksdata, instclass, payload):
         """
         The setup method that should make changes to the runtime environment
         according to the data stored in this object.
@@ -144,13 +144,16 @@ class HelloWorldData(AddonData):
         :type ksdata: pykickstart.base.BaseHandler instance
         :param instclass: distribution-specific information
         :type instclass: pyanaconda.installclass.BaseInstallClass
-
+        :param payload: object managing packages and environment groups
+                        for the installation
+        :type payload: any class inherited from the pyanaconda.packaging.Payload
+                       class
         """
 
         # no actions needed in this addon
         pass
 
-    def execute(self, storage, ksdata, instclass, users):
+    def execute(self, storage, ksdata, instclass, users, payload):
         """
         The execute method that should make changes to the installed system. It
         is called only once in the post-install setup phase.


### PR DESCRIPTION
``setup()`` and ``execute()`` methods now have payload class accessible for
addons.

These methods were changed in anaconda-21.48.22.67 for RHEL-7 and
anaconda-25.9 on Rawhide (for the next Fedora 25).

*Related: rhbz#1288636*