### PR TITLE
Some fixes for Fedora 26

### DIFF
--- a/org_fedora_hello_world/__init__.py
+++ b/org_fedora_hello_world/__init__.py
@@ -1,6 +1,0 @@
-# do not import gui package here because it imports Gtk which causes a traceback
-# if X server is not yet running
-#import gui
-
-import tui
-import ks

--- a/org_fedora_hello_world/categories/__init__.py
+++ b/org_fedora_hello_world/categories/__init__.py
@@ -1,1 +1,0 @@
-import hello_world

--- a/org_fedora_hello_world/gui/__init__.py
+++ b/org_fedora_hello_world/gui/__init__.py
@@ -1,8 +1,0 @@
-"""
-We need org_fedora_hello_world/gui to be a package so that relative imports
-work.
-
-"""
-
-import spokes
-import categories

--- a/org_fedora_hello_world/gui/spokes/__init__.py
+++ b/org_fedora_hello_world/gui/spokes/__init__.py
@@ -1,1 +1,0 @@
-import hello_world

--- a/org_fedora_hello_world/gui/spokes/hello_world.glade
+++ b/org_fedora_hello_world/gui/spokes/hello_world.glade
@@ -21,7 +21,6 @@
         <property name="spacing">6</property>
         <child internal-child="nav_box">
           <object class="GtkEventBox" id="AnacondaSpokeWindow-nav_box1">
-            <property name="app_paintable">True</property>
             <property name="can_focus">False</property>
             <child internal-child="nav_area">
               <object class="GtkGrid" id="AnacondaSpokeWindow-nav_area1">

--- a/org_fedora_hello_world/tui/__init__.py
+++ b/org_fedora_hello_world/tui/__init__.py
@@ -1,1 +1,0 @@
-import spokes

--- a/org_fedora_hello_world/tui/spokes/__init__.py
+++ b/org_fedora_hello_world/tui/spokes/__init__.py
@@ -1,1 +1,0 @@
-import hello_world

--- a/org_fedora_hello_world/tui/spokes/hello_world.py
+++ b/org_fedora_hello_world/tui/spokes/hello_world.py
@@ -35,6 +35,7 @@ from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.tui.spokes import EditTUISpoke
 from pyanaconda.ui.tui.spokes import EditTUISpokeEntry as Entry
 from pyanaconda.ui.common import FirstbootSpokeMixIn
+from pyanaconda.ui.tui.simpleline import Prompt
 
 # export only the HelloWorldSpoke and HelloWorldEditSpoke classes
 __all__ = ["HelloWorldSpoke", "HelloWorldEditSpoke"]
@@ -204,15 +205,16 @@ class HelloWorldSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
         The prompt method that is called by the main loop to get the prompt
         for this screen.
 
+        :see: pyanconda.ui.tui.simpleline.Prompt
+
         :param args: optional argument that can be passed to App.switch_screen*
                      methods
         :type args: anything
         :return: text that should be used in the prompt for the input
-        :rtype: unicode|None
-
+        :rtype: instance of pyanconda.ui.tui.simpleline.Prompt or None
         """
 
-        return _("Enter a new text or leave empty to use the old one: ")
+        return Prompt(_("Enter a new text or leave empty to use the old one"))
 
 class _EditData(object):
     """Auxiliary class for storing data from the example EditSpoke"""


### PR DESCRIPTION
Remove imports in files `__init__.py`    
Imports were in a wrong format and caused some errors in the collect
method. Otherwise, they were useless.

Display the upper bar in the spoke
The upper bar wasn't visible due to a bug in the glade file.

Changed the prompt method
The method prompt should return an instance of Prompt.


