### PR TITLE
Update ks to try multiple getSysroot locations

### DIFF
--- a/org_fedora_hello_world/ks/hello_world.py
+++ b/org_fedora_hello_world/ks/hello_world.py
@@ -23,7 +23,17 @@
 import os.path
 
 from pyanaconda.addons import AddonData
-from pyanaconda.iutil import getSysroot
+
+try:
+    from pyanaconda.core.configuration.anaconda import conf
+    def getSysroot():
+        return conf.target.system_root
+except ImportError:
+    # legacy function call for older anaconda
+    try:
+        from pyanaconda.core.util import getSysroot
+    except ImportError:
+        from pyanaconda.iutil import getSysroot
 
 from pykickstart.options import KSOptionParser
 from pykickstart.errors import KickstartParseError, formatErrorMsg


### PR DESCRIPTION
Anaconda in RHEL8 uses one path for getSysroot.  Fedora 30 uses another, and RHEL7 yet another.

This just tries all three so that the addon should work as expected in all three versions.