### PR TITLE
Fix the compatibility with Fedora 31

### DIFF
--- a/org_fedora_hello_world/categories/hello_world.py
+++ b/org_fedora_hello_world/categories/hello_world.py
@@ -19,9 +19,6 @@
 #
 """Hello world category module"""
 
-
-
-
 from pyanaconda.ui.categories import SpokeCategory
 
 __all__ = ["HelloWorldCategory"]
@@ -30,15 +27,11 @@ N_ = lambda x: x
 
 
 class HelloWorldCategory(SpokeCategory):
-    """
+    """The Hello Word category.
+
     Class for the Hello world category. Category groups related spokes
-    together. Both logically and visually (creates a box on a hub). It
-    references a class of the hub it is supposed to be placed on. On the
-    other hand spokes reference a class of the category they should be
-    included in.
-
+    together. Both logically and visually (creates a box on a hub).
+    Spokes reference a class of the category they should be included in.
     """
 
-    displayOnHubGUI = "SummaryHub"
-    displayOnHubTUI = "SummaryHub"
     title = N_("HELLO WORLD")

--- a/org_fedora_hello_world/gui/spokes/hello_world.py
+++ b/org_fedora_hello_world/gui/spokes/hello_world.py
@@ -88,9 +88,6 @@ class HelloWorldSpoke(FirstbootSpokeMixIn, NormalSpoke):
         :type storage: blivet.Blivet
         :param payload: object storing packaging-related information
         :type payload: pyanaconda.packaging.Payload
-        :param instclass: distribution-specific information
-        :type instclass: pyanaconda.installclass.BaseInstallClass
-
         """
 
         NormalSpoke.__init__(self, data, storage, payload)

--- a/org_fedora_hello_world/ks/hello_world.py
+++ b/org_fedora_hello_world/ks/hello_world.py
@@ -142,8 +142,6 @@ class HelloWorldData(AddonData):
         :param ksdata: data parsed from the kickstart file and set in the
                        installation process
         :type ksdata: pykickstart.base.BaseHandler instance
-        :param instclass: distribution-specific information
-        :type instclass: pyanaconda.installclass.BaseInstallClass
         :param payload: object managing packages and environment groups
                         for the installation
         :type payload: any class inherited from the pyanaconda.packaging.Payload

--- a/org_fedora_hello_world/ks/hello_world.py
+++ b/org_fedora_hello_world/ks/hello_world.py
@@ -23,7 +23,7 @@
 import os.path
 
 from pyanaconda.addons import AddonData
-from pyanaconda.core.util import getSysroot
+from pyanaconda.core.configuration.anaconda import conf
 
 from pykickstart.options import KSOptionParser
 from pykickstart.version import F30
@@ -162,6 +162,6 @@ class HelloWorldData(AddonData):
 
         """
 
-        hello_file_path = os.path.normpath(getSysroot() + HELLO_FILE_PATH)
+        hello_file_path = os.path.normpath(conf.target.system_root + HELLO_FILE_PATH)
         with open(hello_file_path, "w") as fobj:
             fobj.write("%s\n" % self.text)

--- a/org_fedora_hello_world/ks/hello_world.py
+++ b/org_fedora_hello_world/ks/hello_world.py
@@ -26,11 +26,12 @@ from pyanaconda.addons import AddonData
 from pyanaconda.core.util import getSysroot
 
 from pykickstart.options import KSOptionParser
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.version import F30
 
 # export HelloWorldData class to prevent Anaconda's collect method from taking
 # AddonData class instead of the HelloWorldData class
 # :see: pyanaconda.kickstart.AnacondaKSHandler.__init__
+
 __all__ = ["HelloWorldData"]
 
 HELLO_FILE_PATH = "/root/hello_world_addon_output.txt"
@@ -87,22 +88,20 @@ class HelloWorldData(AddonData):
         :param args: the list of arguments from the %addon line
         :type args: list
         """
+        op = KSOptionParser(
+            prog="addon org_fedora_hello_world", version=F30,
+            description="Configure the Hello World Addon.")
 
-        op = KSOptionParser()
-        op.add_option("--reverse", action="store_true", default=False,
-                dest="reverse", help="Reverse the display of the addon text")
-        (opts, extra) = op.parse_args(args=args, lineno=lineno)
+        op.add_argument(
+            "--reverse", action="store_true", default=False, version=F30,
+            dest="reverse", help="Reverse the display of the addon text."
+        )
 
-        # Reject any additional arguments.
-        if extra:
-            msg = "Unhandled arguments on %%addon line for %s" % self.name
-            if lineno != None:
-                raise KickstartParseError(formatErrorMsg(lineno, msg=msg))
-            else:
-                raise KickstartParseError(msg)
+        # Parse the arguments.
+        ns = op.parse_args(args=args, lineno=lineno)
 
-        # Store the result of the option parsing
-        self.reverse = opts.reverse
+        # Store the result of the parsing.
+        self.reverse = ns.reverse
 
     def handle_line(self, line):
         """

--- a/org_fedora_hello_world/tui/spokes/hello_world.py
+++ b/org_fedora_hello_world/tui/spokes/hello_world.py
@@ -82,9 +82,6 @@ class HelloWorldSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
         :type storage: blivet.Blivet
         :param payload: object storing packaging-related information
         :type payload: pyanaconda.packaging.Payload
-        :param instclass: distribution-specific information
-        :type instclass: pyanaconda.installclass.BaseInstallClass
-
         """
 
         NormalTUISpoke.__init__(self, data, storage, payload)
@@ -237,9 +234,6 @@ class HelloWorldEditSpoke(NormalTUISpoke):
         :type storage: blivet.Blivet
         :param payload: object storing packaging-related information
         :type payload: pyanaconda.packaging.Payload
-        :param instclass: distribution-specific information
-        :type instclass: pyanaconda.installclass.BaseInstallClass
-
         """
 
         NormalTUISpoke.__init__(self, data, storage, payload)


### PR DESCRIPTION
* Fix the kickstart support.
* Remove install classes from the docstrings.
* Replace `getSysroot` with the configuration option.
* Remove the unsupported attributes of the category.