### PR TITLE
Adapt to category localization changes

### DIFF
--- a/org_fedora_hello_world/categories/hello_world.py
+++ b/org_fedora_hello_world/categories/hello_world.py
@@ -23,7 +23,7 @@ from pyanaconda.ui.categories import SpokeCategory
 
 __all__ = ["HelloWorldCategory"]
 
-N_ = lambda x: x
+_ = lambda x: x
 
 
 class HelloWorldCategory(SpokeCategory):
@@ -34,4 +34,6 @@ class HelloWorldCategory(SpokeCategory):
     Spokes reference a class of the category they should be included in.
     """
 
-    title = N_("HELLO WORLD")
+    @staticmethod
+    def get_title():
+        return _("HELLO WORLD")


### PR DESCRIPTION
Category title is not provided by a static method to avoid issues
with localization contexts not matching. So fix the example
category accordingly.