### PR TITLE
Fix warning during the pylint execution

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -176,8 +176,7 @@ enable=c-extension-no-member
 [EXCEPTIONS]
 
 # Exceptions that will emit a warning when caught.
-overgeneral-exceptions=BaseException,
-                       Exception
+overgeneral-exceptions=
 
 
 [TYPECHECK]


### PR DESCRIPTION
In the pylintrc we have exception classes for overgeneral configuration. However, these exceptions are not part of the project and pylint complains:

```
pylint: Command line or configuration file:1: UserWarning: 'BaseException' is not a proper value for the 'overgeneral-exceptions' option. Use fully qualified name (maybe 'builtins.BaseException' ?) instead. This will cease to be checked at runtime when the configuration upgrader is released.
pylint: Command line or configuration file:1: UserWarning: 'Exception' is not a proper value for the 'overgeneral-exceptions' option. Use fully qualified name (maybe 'builtins.Exception' ?) instead. This will cease to be checked at runtime when the configuration upgrader is released.
```